### PR TITLE
Fix for including template #16

### DIFF
--- a/Configuration/TCA/sys_template.php
+++ b/Configuration/TCA/sys_template.php
@@ -1,4 +1,6 @@
 <?php
+defined('TYPO3_MODE') or die();
+
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(    
   'rh_recaptcha',    
   'Configuration/TypoScript',    

--- a/Configuration/TCA/sys_template.php
+++ b/Configuration/TCA/sys_template.php
@@ -1,0 +1,6 @@
+<?php
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(    
+  'rh_recaptcha',    
+   'Configuration/TypoScript',    
+   'reCAPTCHA'
+);

--- a/Configuration/TCA/sys_template.php
+++ b/Configuration/TCA/sys_template.php
@@ -1,6 +1,6 @@
 <?php
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(    
   'rh_recaptcha',    
-   'Configuration/TypoScript',    
-   'reCAPTCHA'
+  'Configuration/TypoScript',    
+  'reCAPTCHA'
 );

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -33,12 +33,3 @@ if (defined('\In2code\Powermail\Domain\Model\Form::TABLE_NAME')) {
 		}
 	}
 ');
-
-/**
- * Include TypoScript
- */
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
-    $_EXTKEY,
-    'Configuration/TypoScript',
-    'reCAPTCHA'
-);


### PR DESCRIPTION
This fixed #16. It ports the new code from ext_localconf.php to a newly created TCA/sys_template.php and adds the EXTname.
Tested and working on CMS 8.7.1